### PR TITLE
fix: Add git to build dependencies

### DIFF
--- a/caddy.nix
+++ b/caddy.nix
@@ -21,6 +21,7 @@ final: prev: rec {
               prev.go
               prev.xcaddy
               prev.cacert
+              prev.git
             ];
             dontUnpack = true;
             buildPhase =


### PR DESCRIPTION
Without git, go cannot fetch plugins.